### PR TITLE
Add basic Express backend

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# Rename this file to .env and replace the placeholder with your MongoDB URI
+MONGODB_URI=mongodb://localhost:27017/yourdbname

--- a/README.md
+++ b/README.md
@@ -1,0 +1,23 @@
+# recaught-native
+
+This project contains a React Native front-end and a minimal Express backend that connects to MongoDB.
+
+## Setup
+
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+2. Copy `.env.example` to `.env` and set your `MONGODB_URI`.
+3. Start the backend:
+   ```bash
+   npm run server
+   ```
+4. Start the React Native app (e.g. `npm start`).
+
+The backend exposes the following routes:
+
+- `GET/POST/PUT/DELETE /api/cards`
+- `GET/POST /api/users`
+
+These routes use Mongoose models located in `src/utils/models`.

--- a/backend/server.js
+++ b/backend/server.js
@@ -1,0 +1,32 @@
+import express from 'express';
+import cors from 'cors';
+import dotenv from 'dotenv';
+
+import dbConnect from '../src/utils/lib/dbConnect.js';
+import cardsHandler from '../src/utils/api/cards/index.js';
+import usersHandler from '../src/utils/api/users/index.js';
+
+dotenv.config();
+
+const app = express();
+const PORT = process.env.PORT || 3000;
+
+app.use(cors());
+app.use(express.json());
+
+app.all('/api/cards', (req, res) => cardsHandler(req, res));
+app.all('/api/users', (req, res) => usersHandler(req, res));
+
+// connect to database then start server
+(async () => {
+  try {
+    await dbConnect();
+    console.log('Connected to DB');
+    app.listen(PORT, () => {
+      console.log(`Server listening on port ${PORT}`);
+    });
+  } catch (err) {
+    console.error('Database connection failed', err);
+    process.exit(1);
+  }
+})();

--- a/package.json
+++ b/package.json
@@ -2,11 +2,13 @@
   "name": "recaught-native",
   "version": "1.0.0",
   "main": "index.js",
+  "type": "module",
   "scripts": {
     "start": "expo start",
     "android": "expo start --android",
     "ios": "expo start --ios",
-    "web": "expo start --web"
+    "web": "expo start --web",
+    "server": "node backend/server.js"
   },
   "dependencies": {
     "@expo/vector-icons": "^14.1.0",
@@ -20,7 +22,12 @@
     "react-native": "0.79.5",
     "react-native-safe-area-context": "^5.4.0",
     "react-native-screens": "~4.11.1",
-    "react-native-svg": "15.11.2"
+    "react-native-svg": "15.11.2",
+    "bcrypt": "^5.1.1",
+    "cors": "^2.8.5",
+    "dotenv": "^16.4.5",
+    "express": "^4.19.2",
+    "mongoose": "^8.3.5"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0"


### PR DESCRIPTION
## Summary
- add Express server to serve MongoDB API routes
- document setup instructions
- provide sample `.env` file
- list backend packages and script in `package.json`

## Testing
- `npm test` *(fails: Missing script)*
- `node backend/server.js` *(fails: Cannot find package 'express')*
- `npm install` *(fails: 403 Forbidden due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_687e39b0ab848323a2c266a6fb0e703d