### PR TITLE
Refactor modals into separate components

### DIFF
--- a/src/components/modals/CatchEditModal.js
+++ b/src/components/modals/CatchEditModal.js
@@ -1,0 +1,210 @@
+import React, { useEffect, useRef } from "react";
+import {
+  View,
+  Text,
+  Modal,
+  Animated,
+  Pressable,
+  ScrollView,
+  TextInput,
+  TouchableOpacity,
+  StyleSheet,
+  Easing,
+} from "react-native";
+import Ionicons from "react-native-vector-icons/Ionicons";
+import Colors from "../../../assets/colors/Colors";
+import Typography from "../../../assets/fonts/Typography";
+
+const fieldLabels = {
+  species: "Art",
+  bait: "Fliege",
+  length: "Länge",
+  weight: "Gewicht",
+  time: "Uhrzeit",
+  location: "Ort",
+  notes: "Notizen",
+};
+
+export default function CatchEditModal({
+  visible,
+  catchForm,
+  onChange,
+  onClose,
+  onDelete,
+  onSave,
+}) {
+  const slideAnim = useRef(new Animated.Value(300)).current;
+
+  useEffect(() => {
+    if (visible) {
+      Animated.timing(slideAnim, {
+        toValue: 0,
+        duration: 250,
+        easing: Easing.out(Easing.ease),
+        useNativeDriver: true,
+      }).start();
+    } else {
+      Animated.timing(slideAnim, {
+        toValue: 300,
+        duration: 200,
+        useNativeDriver: true,
+      }).start();
+    }
+  }, [visible]);
+
+  if (!visible) return null;
+
+  return (
+    <Modal transparent animationType="fade" visible={visible} onRequestClose={onClose}>
+      <View style={styles.modalOverlay}>
+        <Animated.View style={[styles.modalContent, { transform: [{ translateY: slideAnim }] }]}>
+          <View style={styles.modalHeader}>
+            <Pressable onPress={onClose} style={styles.modalClose}>
+              <Ionicons name="close" size={24} color={Colors.gray} />
+            </Pressable>
+            <Text style={styles.modalTitle}>Fang bearbeiten</Text>
+            <View style={styles.modalSpacer} />
+          </View>
+
+          <ScrollView>
+            {[['species', 'bait'], ['length', 'weight'], ['time', 'location']].map((pair, row) => (
+              <View key={row} style={styles.modalRow}>
+                {pair.map((field, idx) =>
+                  field ? (
+                    <View key={field} style={styles.modalInputWrapper}>
+                      <Text style={styles.inputTitle}>{fieldLabels[field]}</Text>
+                      <TextInput
+                        style={[styles.modalInput, styles.modalInputHalf]}
+                        placeholder={fieldLabels[field]}
+                        value={catchForm[field]?.toString() || ''}
+                        onChangeText={(text) => onChange(field, text)}
+                      />
+                    </View>
+                  ) : (
+                    <View key={idx} style={styles.modalInputHalf} />
+                  )
+                )}
+              </View>
+            ))}
+
+            <View>
+              <Text style={styles.inputTitle}>Notizen</Text>
+              <TextInput
+                key={fieldLabels.notes}
+                style={styles.modalInput}
+                placeholder={fieldLabels.notes}
+                value={catchForm.notes?.toString() || ''}
+                onChangeText={(text) => onChange('notes', text)}
+              />
+            </View>
+
+            <TouchableOpacity style={styles.toggleTaken} onPress={() => onChange('taken', !catchForm.taken)}>
+              <Text style={styles.modalText}>{catchForm.taken ? '✓ Entnommen' : '✗ Zurückgesetzt'}</Text>
+            </TouchableOpacity>
+
+            <View style={styles.modalButtonRow}>
+              <TouchableOpacity
+                style={[styles.modalButton, { borderWidth: 1, borderColor: Colors.accent }]}
+                onPress={onDelete}
+              >
+                <Text style={[styles.modalButtonText, { color: Colors.accent }]}>Löschen</Text>
+              </TouchableOpacity>
+
+              <TouchableOpacity
+                style={[styles.modalButton, { borderWidth: 1, borderColor: Colors.primary }]}
+                onPress={onSave}
+              >
+                <Text style={[styles.modalButtonText, { color: Colors.primary }]}>Speichern</Text>
+              </TouchableOpacity>
+            </View>
+          </ScrollView>
+        </Animated.View>
+      </View>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  modalOverlay: {
+    flex: 1,
+    justifyContent: 'center',
+    backgroundColor: 'rgba(0,0,0,0.5)',
+  },
+  modalContent: {
+    backgroundColor: 'white',
+    marginHorizontal: 30,
+    borderRadius: 10,
+    padding: 20,
+    maxHeight: '60%',
+  },
+  modalHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    marginBottom: 12,
+  },
+  modalClose: {
+    padding: 4,
+  },
+  modalTitle: {
+    ...Typography.h3,
+    color: Colors.primary,
+  },
+  modalSpacer: {
+    width: 24,
+  },
+  modalRow: {
+    flexDirection: 'row',
+    marginBottom: 8,
+    gap: 16,
+  },
+  modalInputWrapper: {
+    flex: 1,
+  },
+  inputTitle: {
+    ...Typography.body,
+    marginBottom: 4,
+    color: Colors.primary,
+  },
+  modalInput: {
+    borderWidth: 1,
+    borderColor: Colors.gray,
+    borderRadius: 8,
+    padding: 10,
+    marginBottom: 10,
+    ...Typography.body,
+    color: '#ccc',
+    backgroundColor: Colors.white,
+  },
+  modalInputHalf: {
+    width: '100%',
+  },
+  toggleTaken: {
+    paddingVertical: 10,
+    alignItems: 'center',
+    marginBottom: 12,
+    borderRadius: 6,
+    backgroundColor: Colors.grayLight,
+  },
+  modalText: {
+    ...Typography.body,
+    textAlign: 'center',
+    color: '#ccc',
+  },
+  modalButtonRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+  },
+  modalButton: {
+    flex: 1,
+    flexDirection: 'row',
+    justifyContent: 'center',
+    alignItems: 'center',
+    paddingVertical: 12,
+    borderRadius: 8,
+    marginHorizontal: 6,
+  },
+  modalButtonText: {
+    ...Typography.button,
+  },
+});

--- a/src/components/modals/StatsListModal.js
+++ b/src/components/modals/StatsListModal.js
@@ -1,0 +1,114 @@
+import React, { useEffect, useRef, useState } from "react";
+import {
+  View,
+  Text,
+  FlatList,
+  Modal,
+  Pressable,
+  Animated,
+  StyleSheet,
+} from "react-native";
+import Colors from "../../../assets/colors/Colors";
+import Typography from "../../../assets/fonts/Typography";
+
+export default function StatsListModal({ visible, title, data, onClose }) {
+  const overlayOpacity = useRef(new Animated.Value(0)).current;
+  const [show, setShow] = useState(false);
+
+  useEffect(() => {
+    if (visible) {
+      setShow(true);
+      Animated.timing(overlayOpacity, {
+        toValue: 1,
+        duration: 300,
+        useNativeDriver: true,
+      }).start();
+    } else {
+      Animated.timing(overlayOpacity, {
+        toValue: 0,
+        duration: 300,
+        useNativeDriver: true,
+      }).start(() => setShow(false));
+    }
+  }, [visible]);
+
+  if (!show) return null;
+
+  const renderItem = ({ item }) => {
+    const [name, count] = item;
+    return (
+      <View style={styles.modalListItem}>
+        <Text style={styles.modalListCount}>{count}</Text>
+        <Text style={styles.modalListName}>{name}</Text>
+      </View>
+    );
+  };
+
+  return (
+    <Modal visible={show} transparent animationType="fade" onRequestClose={onClose}>
+      <View style={styles.modalContainer}>
+        <Animated.View style={[styles.modalOverlay, { opacity: overlayOpacity }]}> 
+          <Pressable style={{ flex: 1 }} onPress={onClose} />
+        </Animated.View>
+        <View style={styles.modalContent}>
+          <Text style={styles.modalTitle}>{title}</Text>
+          <FlatList data={data} keyExtractor={(item) => item[0]} renderItem={renderItem} />
+        </View>
+      </View>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  modalContainer: {
+    flex: 1,
+    justifyContent: "center",
+    alignItems: "center",
+    position: "relative",
+  },
+  modalOverlay: {
+    position: "absolute",
+    top: 0,
+    bottom: 0,
+    left: 0,
+    right: 0,
+    backgroundColor: "rgba(0,0,0,0.3)",
+    zIndex: 10,
+  },
+  modalContent: {
+    maxHeight: "60%",
+    width: "80%",
+    backgroundColor: "#fff",
+    borderRadius: 16,
+    padding: 16,
+    zIndex: 20,
+    elevation: 5,
+    shadowColor: "#000",
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.25,
+    shadowRadius: 4,
+  },
+  modalTitle: {
+    ...Typography.h3,
+    color: Colors.primary,
+    marginBottom: 12,
+    textAlign: "center",
+  },
+  modalListItem: {
+    flexDirection: "row",
+    alignItems: "center",
+    marginVertical: 6,
+    gap: 12,
+  },
+  modalListCount: {
+    ...Typography.body,
+    color: Colors.secondary,
+    minWidth: 30,
+    textAlign: "right",
+  },
+  modalListName: {
+    ...Typography.body,
+    color: Colors.primary,
+    flexShrink: 1,
+  },
+});

--- a/src/screens/StatisticsScreen.js
+++ b/src/screens/StatisticsScreen.js
@@ -1,10 +1,4 @@
-import React, {
-  useState,
-  useMemo,
-  useCallback,
-  useRef,
-  useEffect,
-} from "react";
+import React, { useState, useMemo, useCallback } from "react";
 import {
   SafeAreaView,
   StyleSheet,
@@ -12,10 +6,6 @@ import {
   Text,
   ScrollView,
   TouchableOpacity,
-  Modal,
-  FlatList,
-  Pressable,
-  Animated,
 } from "react-native";
 import { useFocusEffect } from "@react-navigation/native";
 import Colors from "../../assets/colors/Colors";
@@ -24,6 +14,7 @@ import { TimeFilter, WaterFilter } from "../components/filter/CardsFilters";
 import LineStats from "../components/stats/LineStats";
 import BarStats from "../components/stats/BarStats";
 import { getEnvironmentStats } from "../utils/stats";
+import StatsListModal from "../components/modals/StatsListModal";
 
 const API_BASE_URL = "http://10.116.131.241:3000";
 
@@ -34,30 +25,6 @@ const StatsScreen = ({ token, profile }) => {
 
   const [modalVisible, setModalVisible] = useState(false);
   const [modalType, setModalType] = useState(null);
-
-  const [overlayVisible, setOverlayVisible] = useState(false);
-  const overlayOpacity = useRef(new Animated.Value(0)).current;
-
-  // Overlay einblenden mit Fade
-  const showOverlay = () => {
-    setOverlayVisible(true);
-    Animated.timing(overlayOpacity, {
-      toValue: 1,
-      duration: 300,
-      useNativeDriver: true,
-    }).start();
-  };
-
-  // Overlay ausblenden mit Fade
-  const hideOverlay = () => {
-    Animated.timing(overlayOpacity, {
-      toValue: 0,
-      duration: 300,
-      useNativeDriver: true,
-    }).start(() => {
-      setOverlayVisible(false);
-    });
-  };
 
   useFocusEffect(
     useCallback(() => {
@@ -122,11 +89,9 @@ const StatsScreen = ({ token, profile }) => {
   const openModal = (type) => {
     setModalType(type);
     setModalVisible(true);
-    showOverlay();
   };
 
   const closeModal = () => {
-    hideOverlay();
     setModalVisible(false);
     setModalType(null);
   };
@@ -134,16 +99,6 @@ const StatsScreen = ({ token, profile }) => {
   // Vorschau: Top 6 Items
   const topSpecies = speciesStats.slice(0, 6);
   const topBaits = baitStats.slice(0, 6);
-
-  const renderListItem = ({ item }) => {
-    const [name, count] = item;
-    return (
-      <View style={styles.modalListItem}>
-        <Text style={styles.modalListCount}>{count}</Text>
-        <Text style={styles.modalListName}>{name}</Text>
-      </View>
-    );
-  };
 
   const modalTitle = modalType === "species" ? "Fangstatistik" : "Fliegendose";
   const modalData = modalType === "species" ? speciesStats : baitStats;
@@ -255,35 +210,13 @@ const StatsScreen = ({ token, profile }) => {
         {stats && <BarStats stats={stats} />}
       </ScrollView>
 
-      {overlayVisible && (
-        <Animated.View
-          style={[styles.modalOverlay, { opacity: overlayOpacity }]}
-        >
-          <Pressable style={{ flex: 1 }} onPress={closeModal} />
-        </Animated.View>
-      )}
 
-      {/* Modal */}
-      <Modal
+      <StatsListModal
         visible={modalVisible}
-        transparent
-        animationType="fade"
-        onRequestClose={closeModal}
-      >
-        <View style={styles.modalContainer}>
-          <Pressable style={styles.modalOverlay} onPress={closeModal} />
-          <View style={styles.modalContent}>
-            <Text style={styles.modalTitle}>
-              {modalType === "species" ? "Fangstatistik" : "Fliegendose"}
-            </Text>
-            <FlatList
-              data={modalType === "species" ? speciesStats : baitStats}
-              keyExtractor={(item) => item[0]}
-              renderItem={renderListItem}
-            />
-          </View>
-        </View>
-      </Modal>
+        title={modalTitle}
+        data={modalData}
+        onClose={closeModal}
+      />
     </SafeAreaView>
   );
 };
@@ -406,56 +339,5 @@ const styles = StyleSheet.create({
   empty: {
     fontStyle: "italic",
     color: "#888",
-  },
-  modalContainer: {
-    flex: 1,
-    justifyContent: "center",
-    alignItems: "center",
-    position: "relative",
-  },
-  modalOverlay: {
-    position: "absolute",
-    top: 0,
-    bottom: 0,
-    left: 0,
-    right: 0,
-    backgroundColor: "rgba(0,0,0,0.3)",
-    zIndex: 10,
-  },
-  modalContent: {
-    maxHeight: "60%",
-    width: "80%", // Breite begrenzt und zentriert
-    backgroundColor: "#fff",
-    borderRadius: 16,
-    padding: 16,
-    zIndex: 20,
-    elevation: 5, // Für Android Schatten
-    shadowColor: "#000", // Für iOS Schatten
-    shadowOffset: { width: 0, height: 2 },
-    shadowOpacity: 0.25,
-    shadowRadius: 4,
-  },
-  modalTitle: {
-    ...Typography.h3,
-    color: Colors.primary,
-    marginBottom: 12,
-    textAlign: "center",
-  },
-  modalListItem: {
-    flexDirection: "row",
-    alignItems: "center",
-    marginVertical: 6,
-    gap: 12,
-  },
-  modalListCount: {
-    ...Typography.body,
-    color: Colors.secondary,
-    minWidth: 30,
-    textAlign: "right",
-  },
-  modalListName: {
-    ...Typography.body,
-    color: Colors.primary,
-    flexShrink: 1,
   },
 });


### PR DESCRIPTION
## Summary
- extract statistics modal into `StatsListModal` component
- extract catch edit modal into `CatchEditModal` component
- clean up `StatisticsScreen` and `CardDetailsScreen`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688498a410648323936166944821fcd2