### PR TITLE
Add reusable InputPicker

### DIFF
--- a/src/components/InputPicker.js
+++ b/src/components/InputPicker.js
@@ -1,0 +1,38 @@
+import React, { useState } from "react";
+import { View, Text, Pressable, StyleSheet } from "react-native";
+import { AnimatedDropdown } from "../animations/AnimatedDropdown";
+import Colors from "../../assets/colors/Colors";
+
+export default function InputPicker({ value, onChange, options = [], placeholder = "Ausw\u00e4hlen" }) {
+  const [visible, setVisible] = useState(false);
+
+  return (
+    <View>
+      <Pressable style={styles.input} onPress={() => setVisible(true)}>
+        <Text style={styles.inputText}>{value || placeholder}</Text>
+      </Pressable>
+      <AnimatedDropdown
+        visible={visible}
+        onClose={() => setVisible(false)}
+        options={options}
+        onSelect={onChange}
+        selectedValue={value}
+        labelFallback={placeholder}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  input: {
+    borderWidth: 1,
+    borderColor: Colors.gray,
+    borderRadius: 8,
+    padding: 10,
+    backgroundColor: "#fff",
+    marginBottom: 20,
+  },
+  inputText: {
+    color: "#bbb",
+  },
+});

--- a/src/components/formSteps/formStep2.js
+++ b/src/components/formSteps/formStep2.js
@@ -1,12 +1,9 @@
-import React, { useState, useRef } from "react";
+import React from "react";
 import {
   View,
   Text,
   TextInput,
   Pressable,
-  Modal,
-  FlatList,
-  Animated,
   StyleSheet,
   Alert,
 } from "react-native";
@@ -14,36 +11,11 @@ import * as Location from "expo-location";
 import Colors from "../../../assets/colors/Colors"; // Importiere deine Farben
 import Typography from "../../../assets/fonts/Typography"; // Importiere deine Typografie
 import { selectionOptions } from "../../utils/selectionOptions"; // Dein Auswahloptionen-Modul
+import InputPicker from "../InputPicker";
 
 const API_BASE_URL = "http://10.116.131.241:3000"; // Stelle sicher, dass dies die richtige IP-Adresse des Servers ist
 
 export default function Step2({ data, onChange }) {
-  const [modalState, setModalState] = useState({ key: null, visible: false });
-  const slideAnim = useRef(new Animated.Value(300)).current;
-
-  const openModal = (key) => {
-    setModalState({ key, visible: true });
-    Animated.timing(slideAnim, {
-      toValue: 0,
-      duration: 250,
-      useNativeDriver: true,
-    }).start();
-  };
-
-  const closeModal = () => {
-    Animated.timing(slideAnim, {
-      toValue: 300,
-      duration: 200,
-      useNativeDriver: true,
-    }).start(() => {
-      setModalState({ key: null, visible: false });
-    });
-  };
-
-  const handleSelection = (value) => {
-    onChange({ [modalState.key]: value });
-    closeModal();
-  };
 
   // Funktion, um Wetterdaten vom Server zu holen
   const fetchWeatherData = async () => {
@@ -93,14 +65,12 @@ export default function Step2({ data, onChange }) {
 
       <View style={styles.inputGroup}>
         <Text style={styles.label}>Wetter</Text>
-        <Pressable
-          style={styles.selectInput}
-          onPress={() => openModal("weather")}
-        >
-          <Text style={styles.selectText}>
-            {data.weather || "Wetter auswählen"}
-          </Text>
-        </Pressable>
+        <InputPicker
+          value={data.weather}
+          onChange={(v) => onChange({ weather: v })}
+          options={selectionOptions.weather}
+          placeholder="Wetter auswählen"
+        />
       </View>
 
       <View style={styles.row}>
@@ -134,14 +104,12 @@ export default function Step2({ data, onChange }) {
       <View style={styles.row}>
         <View style={styles.inputGroup}>
           <Text style={styles.label}>Windrichtung</Text>
-          <Pressable
-            style={styles.selectInput}
-            onPress={() => openModal("wind")}
-          >
-            <Text style={styles.selectText}>
-              {data.wind || "Windrichtung auswählen"}
-            </Text>
-          </Pressable>
+          <InputPicker
+            value={data.wind}
+            onChange={(v) => onChange({ wind: v })}
+            options={selectionOptions.wind}
+            placeholder="Windrichtung auswählen"
+          />
         </View>
 
         <View style={styles.inputGroup}>
@@ -160,11 +128,12 @@ export default function Step2({ data, onChange }) {
 
       <View style={styles.inputGroup}>
         <Text style={styles.label}>Mondphase</Text>
-        <Pressable style={styles.selectInput} onPress={() => openModal("moon")}>
-          <Text style={styles.selectText}>
-            {data.moon || "Mondphase auswählen"}
-          </Text>
-        </Pressable>
+        <InputPicker
+          value={data.moon}
+          onChange={(v) => onChange({ moon: v })}
+          options={selectionOptions.moon}
+          placeholder="Mondphase auswählen"
+        />
       </View>
 
       {/* Button zum Abrufen der Wetterdaten */}
@@ -174,30 +143,6 @@ export default function Step2({ data, onChange }) {
         </Text>
       </Pressable>
 
-      {modalState.visible && (
-        <Modal transparent animationType="none" visible={modalState.visible}>
-          <Pressable style={styles.modalOverlay} onPress={closeModal} />
-          <Animated.View
-            style={[
-              styles.modalContent,
-              { transform: [{ translateY: slideAnim }] },
-            ]}
-          >
-            <FlatList
-              data={selectionOptions[modalState.key]}
-              keyExtractor={(item) => item}
-              renderItem={({ item }) => (
-                <Pressable
-                  style={styles.modalItem}
-                  onPress={() => handleSelection(item)}
-                >
-                  <Text style={styles.modalItemText}>{item}</Text>
-                </Pressable>
-              )}
-            />
-          </Animated.View>
-        </Modal>
-      )}
     </View>
   );
 }
@@ -234,42 +179,6 @@ const styles = StyleSheet.create({
     backgroundColor: "#fff",
     fontSize: 14,
     marginBottom: 20,
-  },
-  selectInput: {
-    borderWidth: 1,
-    borderColor: Colors.gray,
-    borderRadius: 8,
-    padding: 10,
-    marginBottom: 20,
-  },
-  selectText: {
-    color: "#bbb",
-  },
-  modalOverlay: {
-    flex: 1,
-    backgroundColor: "rgba(0,0,0,0.3)",
-  },
-  modalContent: {
-    maxHeight: "50%",
-    backgroundColor: "#fff",
-    paddingVertical: 12,
-    paddingBottom: 30,
-    borderTopLeftRadius: 16,
-    borderTopRightRadius: 16,
-    position: "absolute",
-    bottom: 0,
-    left: 0,
-    right: 0,
-  },
-  modalItem: {
-    padding: 16,
-    borderBottomWidth: 1,
-    borderBottomColor: "#eee",
-  },
-  modalItemText: {
-    fontSize: 16,
-    color: Colors.primary,
-    textAlign: "center",
   },
   button: {
     backgroundColor: Colors.primary,

--- a/src/components/formSteps/formStep3.js
+++ b/src/components/formSteps/formStep3.js
@@ -1,46 +1,17 @@
 // components/formSteps/formStep3.js
-import React, { useState, useRef } from "react";
+import React from "react";
 import {
   View,
   Text,
   TextInput,
-  Pressable,
-  Modal,
-  FlatList,
-  Animated,
   StyleSheet,
 } from "react-native";
 import Colors from "../../../assets/colors/Colors";
 import Typography from "../../../assets/fonts/Typography";
 import { selectionOptions } from "../../utils/selectionOptions";
+import InputPicker from "../InputPicker";
 
 export default function Step3({ data, onChange }) {
-  const [modalState, setModalState] = useState({ key: null, visible: false });
-  const slideAnim = useRef(new Animated.Value(300)).current;
-
-  const openModal = (key) => {
-    setModalState({ key, visible: true });
-    Animated.timing(slideAnim, {
-      toValue: 0,
-      duration: 250,
-      useNativeDriver: true,
-    }).start();
-  };
-
-  const closeModal = () => {
-    Animated.timing(slideAnim, {
-      toValue: 300,
-      duration: 200,
-      useNativeDriver: true,
-    }).start(() => {
-      setModalState({ key: null, visible: false });
-    });
-  };
-
-  const handleSelection = (value) => {
-    onChange({ [modalState.key]: value });
-    closeModal();
-  };
 
   return (
     <View style={styles.wrapper}>
@@ -72,54 +43,25 @@ export default function Step3({ data, onChange }) {
       {/* Wasserfarbe */}
       <View style={styles.inputGroup}>
         <Text style={styles.label}>Wasserfarbe</Text>
-        <Pressable
-          style={styles.selectInput}
-          onPress={() => openModal("watercolor")}
-        >
-          <Text style={styles.selectText}>
-            {data.watercolor || "Wasserfarbe auswählen"}
-          </Text>
-        </Pressable>
+        <InputPicker
+          value={data.watercolor}
+          onChange={(v) => onChange({ watercolor: v })}
+          options={selectionOptions.watercolor}
+          placeholder="Wasserfarbe auswählen"
+        />
       </View>
 
       {/* Wasserstand */}
       <View style={styles.inputGroup}>
         <Text style={styles.label}>Wasserstand</Text>
-        <Pressable
-          style={styles.selectInput}
-          onPress={() => openModal("waterlevel")}
-        >
-          <Text style={styles.selectText}>
-            {data.waterlevel || "Wasserstand auswählen"}
-          </Text>
-        </Pressable>
+        <InputPicker
+          value={data.waterlevel}
+          onChange={(v) => onChange({ waterlevel: v })}
+          options={selectionOptions.waterlevel}
+          placeholder="Wasserstand auswählen"
+        />
       </View>
 
-      {/* Modal */}
-      {modalState.visible && (
-        <Modal transparent animationType="none" visible={modalState.visible}>
-          <Pressable style={styles.modalOverlay} onPress={closeModal} />
-          <Animated.View
-            style={[
-              styles.modalContent,
-              { transform: [{ translateY: slideAnim }] },
-            ]}
-          >
-            <FlatList
-              data={selectionOptions[modalState.key]}
-              keyExtractor={(item) => item}
-              renderItem={({ item }) => (
-                <Pressable
-                  style={styles.modalItem}
-                  onPress={() => handleSelection(item)}
-                >
-                  <Text style={styles.modalItemText}>{item}</Text>
-                </Pressable>
-              )}
-            />
-          </Animated.View>
-        </Modal>
-      )}
     </View>
   );
 }
@@ -155,41 +97,5 @@ const styles = StyleSheet.create({
     padding: 10,
     backgroundColor: "#fff",
     fontSize: 14,
-  },
-  selectInput: {
-    borderWidth: 1,
-    borderColor: Colors.gray,
-    borderRadius: 8,
-    padding: 10,
-    backgroundColor: "#fff",
-  },
-  selectText: {
-    color: "#bbb",
-  },
-  modalOverlay: {
-    flex: 1,
-    backgroundColor: "rgba(0,0,0,0.3)",
-  },
-  modalContent: {
-    maxHeight: "50%",
-    backgroundColor: "#fff",
-    paddingVertical: 12,
-    paddingBottom: 30,
-    borderTopLeftRadius: 16,
-    borderTopRightRadius: 16,
-    position: "absolute",
-    bottom: 0,
-    left: 0,
-    right: 0,
-  },
-  modalItem: {
-    padding: 16,
-    borderBottomWidth: 1,
-    borderBottomColor: "#eee",
-  },
-  modalItemText: {
-    fontSize: 16,
-    color: Colors.primary,
-    textAlign: "center",
   },
 });


### PR DESCRIPTION
## Summary
- create `InputPicker` component that slides up using existing `AnimatedDropdown`
- refactor Step2 and Step3 forms to use `InputPicker` for weather and water related fields

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6884a1c7873c832399c57dcdee547e2f